### PR TITLE
refactor: find: rm useless condition

### DIFF
--- a/src/find.ts
+++ b/src/find.ts
@@ -53,9 +53,7 @@ export default function find<Node extends ASTNode>(
 
   const matches: Array<Match<Node>> = []
 
-  const nodeTypes = Array.isArray(matcher.nodeType)
-    ? matcher.nodeType
-    : matcher.nodeType
+  const nodeTypes = matcher.nodeType
     ? [matcher.nodeType]
     : ['Node']
 


### PR DESCRIPTION
Both parts of expression:

```js
const nodeTypes = Array.isArray(matcher.nodeType)
    ? matcher.nodeType
    : matcher.nodeType
```

Returns same result, and can be simplified to:

```js
matcher.nodeType
```

Just landed this case to [@putout/plugin-simplify-ternary](https://github.com/coderaiser/putout/tree/master/packages/plugin-simplify-ternary) 🎉 