### PR TITLE
Remove early initialization of nodePathPlugin that causes ast-types Scope to malfunction

### DIFF
--- a/src/babel/babelAstTypes.ts
+++ b/src/babel/babelAstTypes.ts
@@ -6,7 +6,6 @@ import lodash from 'lodash'
 const { memoize, omit, mapValues } = lodash
 import fork from 'ast-types/fork'
 import { Fork } from 'ast-types/types'
-import nodePathPlugin from 'ast-types/lib/node-path'
 
 const babelAstTypes: (t?: typeof defaultTypes) => ReturnType<typeof fork> =
   memoize((t: typeof defaultTypes = defaultTypes): ReturnType<typeof fork> => {
@@ -14,8 +13,6 @@ const babelAstTypes: (t?: typeof defaultTypes) => ReturnType<typeof fork> =
       const types = fork.use(typesPlugin)
       const { builtInTypes, Type } = types
       const { def, or } = Type
-
-      fork.use(nodePathPlugin)
 
       def('Node').field('type', builtInTypes.string)
       def('Comment')

--- a/test/astx/bugs_scope.ts
+++ b/test/astx/bugs_scope.ts
@@ -1,0 +1,17 @@
+import { TransformOptions } from '../../src'
+import { astxTestcase } from '../astxTestcase'
+import { NodePath as AstTypesNodePath } from 'ast-types/lib/node-path'
+import dedent from 'dedent-js'
+
+astxTestcase({
+  file: __filename,
+  input: dedent`
+    const foo = 1;
+  `,
+  parsers: ['babel', 'babel/tsx'],
+  astx: ({ astx, report }: TransformOptions): void => {
+    const path = astx.find`const foo = 1;`.paths[0]
+    report((path as AstTypesNodePath).scope !== null)
+  },
+  expectedReports: [true],
+})


### PR DESCRIPTION
Hi!

First of all, for context: I am trying my hand at code mods and found astx after experimenting some with jscodeshift. This project is great! I love that pattern matching on the AST no longer gets in my way. Thank you :)

I have hit two obstacles trying to use ast-types's Scope functionality on matched NodePaths (see [ast-types readme](https://github.com/benjamn/ast-types/tree/v0.16.1#scope)). I figure this is not something you have sought to support so far, but I have still managed to work around my immediate obstacles and have produced a couple of small changes to propose.

This PR is for the first issue, which I am more confident about addressing. It removes `fork.use(nodePathPlugin)` in `babelAstTypes`, which I believe is done too early and is also not needed since ast-types already handles that for us. (I will explain the second issue in a comment.)

That early use of `nodePathPlugin` caused the `scope` property on NodePath instances to be always `null`. This is because `nodePathPlugin` uses `scopePlugin`, which in turns uses `typesPlugin`  at initialization time -- [specifically the `namedTypes` object it provides](https://github.com/benjamn/ast-types/blob/v0.14.2/lib/scope.ts#L71-L84). But when `scopePlugin` is initialized too early, `namedTypes` is still empty: it only gets populated when the definitions of `typesPlugin` are finalized, which ast-types [gets in the right order](https://github.com/benjamn/ast-types/blob/v0.14.2/fork.ts#L15-L38).

I could not find other parts of ast-types that are similarly sensitive to ordering, so I understand this is not much of an issue for astx until it supports scopes.

---

This PR first adds a test that witnesses the scope issue, then fixes the broken test by removing the `fork.use(nodePathPlugin)` call.

The test is a little odd because it checks that `scope` is non-null, though astx omits `scope` when redefining the NodePath interface, so I have a type mismatch. Adding scope to that re-definition looks like a big change that I can't really see as a good idea from where I stand.